### PR TITLE
Security links

### DIFF
--- a/IAE-next-steps.md
+++ b/IAE-next-steps.md
@@ -5,7 +5,6 @@ title: What's Next
 ---
 ### What's New for openIAE?
 Are you up for a challenge? We have posted a Request for Information (RFI) for Entity Validation Serivces. Read more [here](https://gsa.github.io/openIAE/sourcessought)
-Check out the IAE Common Serivces Platform Architecture [Open Source Framework](https://github.com/GSA/IAE-Architecture/blob/master/to-be/architecture/technology-architecture/iae-csp-architecture.pdf) Let us know what you think!
 
 ### What's Next for openIAE?
 


### PR DESCRIPTION
A Netsparker scan was performed. We were given a recommendation related to links that open in a new window. This PR modifies those links based on the feedback and suggestion made.

1. Links in the `_site` directory were ignored as it is the result of the Jekyll build itself; therefore, those links will be updated when the Jekyll build is run again.

2. Links in the `node_modules` were ignored as they are the result of running `npm install` and the code is outside the control of GSA.